### PR TITLE
dynamic fee estimation

### DIFF
--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -46,22 +46,33 @@ func ConstructTransfer(from string, to string, amount *big.Int) ([]byte, error) 
 	fromAddress := parseAddress(from)
 	toAddress := parseAddress(to)
 
+	// Additional context on gas parameters can be found here:
+	// https://github.com/ethereum/pm/issues/328#issuecomment-853612573
+	gasPrice, err := Client.SuggestGasPrice(ctx)
+	if err != nil {
+		return []byte{}, errors.Wrapf(err, "cannot fetch suggested gas price")
+	}
+
+	gasTipCap, err := Client.SuggestGasTipCap(ctx)
+	if err != nil {
+		return []byte{}, errors.Wrapf(err, "cannot fetch suggested gas tip cap")
+	}
+
+	// Double the tip for timely execution
+	multipliedGasTip := new(big.Int).Mul(gasTipCap, big.NewInt(2))
+
 	nonce, err := Client.PendingNonceAt(ctx, fromAddress)
 	if err != nil {
 		return []byte{}, errors.Wrapf(err, "cannot fetch nonce for address %s", from)
 	}
 
 	gasLimit := uint64(21000)
-	// maxPriorityFeePerGas = 2 Gwei
-	tip := big.NewInt(2000000000)
-	// maxFeePerGas = 20 Gwei
-	feeCap := big.NewInt(20000000000)
 
 	return messageToSign(types.NewTx(&types.DynamicFeeTx{
 		ChainID:   params.SepoliaChainConfig.ChainID,
 		Nonce:     nonce,
-		GasFeeCap: feeCap,
-		GasTipCap: tip,
+		GasFeeCap: gasPrice,
+		GasTipCap: multipliedGasTip,
 		Gas:       gasLimit,
 		To:        &toAddress,
 		Value:     amount,


### PR DESCRIPTION
add a little multiplier to the tip just in case things get congested :) 

test txs:
- no tip multiplier: https://sepolia.etherscan.io/tx/0xa1afa63444d1dfbd7cd7471a8a6834fb4fea549c25e9bd21eaf0b3163056a203
- with 2x tip multiplier: https://sepolia.etherscan.io/tx/0x97e4f09c2bbaaede3188ed58e20127c83888075940df2b0794f7237349e8d148

example of tx during fee spike: https://sepolia.etherscan.io/tx/0xd1e9efe4530721b6c3904eb8ae135c030932cbf59b3b6429646727c071e8eff4
- to mitigate this, we just needed a bigger base fee; doesn't seem like transactions were fighting against each other based on miner tips